### PR TITLE
Throw IllegalStateException instead of IllegalAccessError

### DIFF
--- a/src/main/java/org/organicdesign/fp/collections/PersistentHashMap.java
+++ b/src/main/java/org/organicdesign/fp/collections/PersistentHashMap.java
@@ -497,7 +497,7 @@ public class PersistentHashMap<K,V> extends AbstractUnmodMap<K,V>
 
         private void ensureEditable() {
             if(edit.get() == null)
-                throw new IllegalAccessError("Mutable used after immutable! call");
+                throw new IllegalStateException("Mutable used after immutable! call");
         }
     }
 

--- a/src/main/java/org/organicdesign/fp/collections/PersistentVector.java
+++ b/src/main/java/org/organicdesign/fp/collections/PersistentVector.java
@@ -529,7 +529,7 @@ public class PersistentVector<E> extends UnmodList.AbstractUnmodList<E>
 
         private void ensureEditable() {
             if (root.edit.get() == null) {
-                throw new IllegalAccessError("Mutable used after immutable! call");
+                throw new IllegalStateException("Mutable used after immutable! call");
             }
             //		root = editableRoot(root);
             //		tail = editableTail(tail);
@@ -546,7 +546,7 @@ public class PersistentVector<E> extends UnmodList.AbstractUnmodList<E>
             //		Thread owner = root.edit.get();
             //		if(owner != null && owner != Thread.currentThread())
             //			{
-            //			throw new IllegalAccessError("Mutation release by non-owner thread");
+            //			throw new IllegalStateException("Mutation release by non-owner thread");
             //			}
             root.edit.set(null);
             F[] trimmedTail = (F[]) new Object[size - tailoff()];

--- a/src/test/java/org/organicdesign/fp/collections/PersistentHashMapTest.java
+++ b/src/test/java/org/organicdesign/fp/collections/PersistentHashMapTest.java
@@ -543,7 +543,7 @@ public class PersistentHashMapTest {
         assertEquals(0, t.size());
     }
 
-    @Test (expected = IllegalAccessError.class)
+    @Test (expected = IllegalStateException.class)
     public void mutableHashEx1() {
         PersistentHashMap<String,Integer> m = PersistentHashMap.empty();
         PersistentHashMap.MutableHashMap<String,Integer> t = m.mutable();


### PR DESCRIPTION
This brings the behavior of PersistentHashMap and PersistentVector in
line with the Java Collections framework where we throw subclasses of
RuntimeExceptions over Errors.

I've found that as-is I often need to use something along the lines of:

    try {} catch (RuntimeException | IllegalAccessError ex) {}

if I know the underyling code uses Paguro.