### PR TITLE
Allow passing Entry subclasses to Map factory methods

### DIFF
--- a/src/main/java/org/organicdesign/fp/collections/PersistentHashMap.java
+++ b/src/main/java/org/organicdesign/fp/collections/PersistentHashMap.java
@@ -156,7 +156,7 @@ public class PersistentHashMap<K,V> extends AbstractUnmodMap<K,V>
     @SuppressWarnings("WeakerAccess")
     public static <K,V> @NotNull PersistentHashMap<K,V> ofEq(
             Equator<K> eq,
-            @Nullable Iterable<Map.Entry<K,V>> es) {
+            @Nullable Iterable<? extends Map.Entry<K,V>> es) {
         if (es == null) { return empty(eq); }
         MutHashMap<K,V> map = emptyMutable(eq);
         for (Map.Entry<K,V> entry : es) {
@@ -179,7 +179,7 @@ public class PersistentHashMap<K,V> extends AbstractUnmodMap<K,V>
 
      @return a new PersistentHashMap of the given key/value pairs
       */
-    public static <K,V> @NotNull PersistentHashMap<K,V> of(@Nullable Iterable<Map.Entry<K,V>> kvPairs) {
+    public static <K,V> @NotNull PersistentHashMap<K,V> of(@Nullable Iterable<? extends Map.Entry<K,V>> kvPairs) {
         if (kvPairs == null) { return empty(); }
         PersistentHashMap<K,V> m = empty();
         MutHashMap<K,V> map = m.mutable();

--- a/src/main/java/org/organicdesign/fp/collections/PersistentTreeMap.java
+++ b/src/main/java/org/organicdesign/fp/collections/PersistentTreeMap.java
@@ -61,7 +61,7 @@ public class PersistentTreeMap<K,V> extends AbstractUnmodMap<K,V>
      any null Entries.
      */
     public static <K extends Comparable<K>,V> PersistentTreeMap<K,V>
-    of(Iterable<Map.Entry<K,V>> es) {
+    of(Iterable<? extends Map.Entry<K,V>> es) {
         if (es == null) { return empty(); }
         PersistentTreeMap<K,V> map = new PersistentTreeMap<>(Equator.defaultComparator(), null, 0);
         for (Map.Entry<K,V> entry : es) {
@@ -87,7 +87,7 @@ public class PersistentTreeMap<K,V> extends AbstractUnmodMap<K,V>
      @return a new PersistentTreeMap of the specified comparator and the given key/value pairs
      */
     public static <K,V> PersistentTreeMap<K,V>
-    ofComp(Comparator<? super K> comp, Iterable<Map.Entry<K,V>> kvPairs) {
+    ofComp(Comparator<? super K> comp, Iterable<? extends Map.Entry<K,V>> kvPairs) {
         if (kvPairs == null) { return new PersistentTreeMap<>(comp, null, 0); }
         PersistentTreeMap<K,V> map = new PersistentTreeMap<>(comp, null, 0);
         for (Map.Entry<K,V> entry : kvPairs) {
@@ -104,7 +104,7 @@ public class PersistentTreeMap<K,V> extends AbstractUnmodMap<K,V>
      items will blow up at runtime.  Either a withComparator() method will be added, or this will
      be removed.
      */
-    final static public PersistentTreeMap EMPTY =
+    final static public PersistentTreeMap<?, ?> EMPTY =
             new PersistentTreeMap<>(Equator.defaultComparator(), null, 0);
 
     /**

--- a/src/test/java/org/organicdesign/fp/collections/PersistentHashMapTest.java
+++ b/src/test/java/org/organicdesign/fp/collections/PersistentHashMapTest.java
@@ -24,7 +24,6 @@ import org.organicdesign.fp.function.Fn1;
 import org.organicdesign.fp.oneOf.Option;
 import org.organicdesign.fp.tuple.Tuple2;
 
-import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.organicdesign.fp.FunctionUtils.ordinal;
 import static org.organicdesign.fp.StaticImports.*;
@@ -1617,5 +1616,27 @@ public class PersistentHashMapTest {
         assertFalse(h2 == h2.assoc(null, "nada"));
         assertNotEquals(h2, h2.assoc(null, "nada"));
         assertEquals(h2.size() + 1, h2.assoc(null, "nada").size());
+    }
+
+    @Test
+    public void testOfIterable() {
+        PersistentHashMap<String, String> map = PersistentHashMap.<String, String>empty()
+                .assoc("a", "a")
+                .assoc("b", "b")
+                .assoc("c", "c")
+                .assoc("d", "d");
+        PersistentHashMap<String, String> map2 = PersistentHashMap.<String, String>empty()
+                .assoc("e", "e")
+                .assoc("f", "f")
+                .assoc("g", "g")
+                .assoc("h", "h");
+
+        assertEquals(map.without("a").without("b"), PersistentHashMap.of(
+                map.filter(entry -> !(entry.getKey().equals("a") || entry.getKey().equals("b")))));
+
+        ImMap<String, String> combined = map.concat(map2).toImMap(x -> x);
+        assertEquals(combined, PersistentTreeMap.of(map.concat(map2)));
+
+        assertEquals(map, PersistentTreeMap.of(map));
     }
 }

--- a/src/test/java/org/organicdesign/fp/collections/PersistentTreeMapTest.java
+++ b/src/test/java/org/organicdesign/fp/collections/PersistentTreeMapTest.java
@@ -925,4 +925,24 @@ public class PersistentTreeMapTest {
                                                                Fn1.identity()),
                                         max);
     }
+
+    @Test public void testOfIterable() {
+        PersistentTreeMap<String, String> map = PersistentTreeMap.<String, String>empty()
+                .assoc("a", "a")
+                .assoc("b", "b")
+                .assoc("c", "c")
+                .assoc("d", "d");
+        PersistentTreeMap<String, String> map2 = PersistentTreeMap.<String, String>empty()
+                .assoc("e", "e")
+                .assoc("f", "f")
+                .assoc("g", "g")
+                .assoc("h", "h");
+
+        assertEquals(map.without("a").without("b"), PersistentTreeMap.of(map.drop(2)));
+
+        ImSortedMap<String, String> combined = map.concat(map2).toImSortedMap(Equator.defaultComparator(), entry -> entry);
+        assertEquals(combined, PersistentTreeMap.of(map.concat(map2)));
+
+        assertEquals(map, PersistentTreeMap.of(map));
+    }
 }


### PR DESCRIPTION
Change the factory methods to accept a covariant type (e.g., Iterable<? extends Map.Entry>), which allows passing Iterables of UnEntry.

Note: perhaps I'm just using the library wrong, but I ran into this issue when I was attempting to merge two maps. It seemed to me that I should be able to do this:

```java
PersistentTreeMap.of(map.concat(map2));
```

While I know it's doable like so, to me it seems like an unnecessary limitation, and this form is more verbose:

```java
map.concat(map2).toImSortedMap(Equator.defaultComparator(), entry -> entry);
```

(Would be happy to be shown a better way to merge two maps).

Another consequence of making it covariant is that you can now pass a Persistent map instance to the factory method.