### PR TITLE
feat: add jpms support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@ http://mvnrepository.com/artifact/org.organicdesign/Paguro
 	-->
 	<groupId>org.organicdesign</groupId>
 	<artifactId>Paguro</artifactId>
-	<version>3.10.4</version>
+	<version>3.11.0</version>
 	<packaging>jar</packaging>
 
 	<name>Paguro</name>
@@ -76,8 +76,13 @@ http://mvnrepository.com/artifact/org.organicdesign/Paguro
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.12.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<id>enforce-maven</id>
@@ -97,7 +102,7 @@ http://mvnrepository.com/artifact/org.organicdesign/Paguro
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>
@@ -115,7 +120,7 @@ http://mvnrepository.com/artifact/org.organicdesign/Paguro
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -129,7 +134,7 @@ http://mvnrepository.com/artifact/org.organicdesign/Paguro
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<!-- JavaDoc wasn't providing the right links to the Java APIs with the default version of the plugin on my machine. -->
-				<version>3.4.1</version>
+				<version>3.6.3</version>
 				<configuration>
 					<additionalOptions>-Xdoclint:none</additionalOptions>
 				</configuration>
@@ -145,7 +150,7 @@ http://mvnrepository.com/artifact/org.organicdesign/Paguro
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<goals>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module paguro {
+    requires java.base;
+    requires static org.jetbrains.annotations;
+
+    exports org.organicdesign.fp;
+    exports org.organicdesign.fp.collections;
+    exports org.organicdesign.fp.function;
+    exports org.organicdesign.fp.indent;
+    exports org.organicdesign.fp.oneOf;
+    exports org.organicdesign.fp.tuple;
+    exports org.organicdesign.fp.type;
+    exports org.organicdesign.fp.xform;
+}


### PR DESCRIPTION
## Summary

Users can now use this module via the Java Platform Module System, with the following `requires` declaration in their module:

```java
module my.module {
  requires paguro;
}
```

## Changelog

- feat: add `module-info.java` descriptor
- chore: update all maven plugins to latest
- chore: bump version → `3.11.0`

cc / @GlenKPeterson 